### PR TITLE
Add types to exports field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/esm/coloris.js",
-      "require": "./dist/umd/coloris.js"
+      "require": "./dist/umd/coloris.js",
+      "types": "./dist/coloris.d.ts"
     },
     "./dist/coloris.css": {
       "import": "./dist/coloris.css",


### PR DESCRIPTION
With ESM modules and recent node / yarn / TS versions, attempting to ` import {...} from "@melloware/coloris"` gives the following error:
 
```
  There are types at '/home/user/git/coloris-react/.yarn/cache/@melloware-coloris-npm-0.18.0-1e5f08e615-dc29675acc.zip/node_modules/@melloware/coloris/dist/coloris.d.ts', but this result could not be resolved when respecting package.json "exports". The '@melloware/coloris' library may need to update its package.json or typings.
```

The `exports` object in the `package.json` needs to explicitly allow access to the file with the typings; if the typings file is not in the same directory with the same name.

https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing