### PR TITLE
Expose new functions in ESM wrapper

### DIFF
--- a/esm-wrapper.js
+++ b/esm-wrapper.js
@@ -7,6 +7,9 @@ const _init = Coloris.init;
 const _set = Coloris.set;
 const _wrap = Coloris.wrap;
 const _close = Coloris.close;
+const _setInstance = Coloris.setInstance;
+const _removeInstance = Coloris.removeInstance;
+const _updatePosition = Coloris.updatePosition;
 export default Coloris;
 export {
   _coloris as coloris,
@@ -14,4 +17,7 @@ export {
   _init as init,
   _set as set,
   _wrap as wrap,
+  _setInstance as setInstance,
+  _removeInstance as removeInstance,
+  _updatePosition as updatePosition,
 }; 


### PR DESCRIPTION
Some time ago coloris added the new functions `setInstance`, `removeInstance`, and `updatePosition`. We also added them in the type definitions. But attempting to use those functions when importing from the ESM modules gives the following error:

```
✘ [ERROR] No matching export in "../../.yarn/cache/@melloware-coloris-patch-884dd6decc-cd6a043de1.zip/node_modules/@melloware/coloris/dist/esm/coloris.js" for import "setInstance"
✘ [ERROR] No matching export in "../../.yarn/cache/@melloware-coloris-patch-884dd6decc-cd6a043de1.zip/node_modules/@melloware/coloris/dist/esm/coloris.js" for import "removeInstance"
✘ [ERROR] No matching export in "../../.yarn/cache/@melloware-coloris-patch-884dd6decc-cd6a043de1.zip/node_modules/@melloware/coloris/dist/esm/coloris.js" for import "updatePosition"
```

ESM requires all exports to be named explicitly, so they need to be added to the `esm-wrapper.js`