### PR TITLE
Check if the current Coloris' Element Doesn't Have a `value` Attribute 

### DIFF
--- a/src/coloris.js
+++ b/src/coloris.js
@@ -345,7 +345,7 @@ return ((window, document, Math, undefined) => {
     attachVirtualInstance(event.target);
 
     currentEl = event.target;
-    oldColor = currentEl.value;
+    oldColor = currentEl.value ? currentEl.value : '#ffffff00';
     currentFormat = getColorFormatFromStr(oldColor);
     picker.classList.add('clr-open');
     


### PR DESCRIPTION
This is just a simple one line change that checks when the user tries to open the color picker of a Coloris instance that doesn't have a `value` attribute set for it's `el`, it'll use the default hex color that is the same as the color preview when it doesn't detect a `value`.

All g if this doesn't get merged, I know it's just a lil' change but it works! xd